### PR TITLE
correct aaa

### DIFF
--- a/src/aaa.jl
+++ b/src/aaa.jl
@@ -118,6 +118,9 @@ function aaa(y::AbstractVector{<:Number}, z::AbstractVector{<:Number};
             break
         end
 
+        # To make sure columns of V won't be thrown away in svd and prevent overfitting
+        if n>=((m+1)>>1) break end
+
         _, j = findmax(abs, R)
         push!(node_index, j)
         delete!(test_index, j)


### PR DESCRIPTION
There is a potential issue in the `aaa` function: when the Lowner matrix `L` would be *wide* matrix (i.e., more columns than rows) in next iteration, the iteration may does not terminate immediately. As a result, `L` may become a wide matrix, which leads to two problems:

1. For a matrix `L` of size `m × n` with `m < n` and `rank(L) = m`, although mathematically the SVD of `L` will have zero singular values, in practice `LinearAlgebra.svd(L)` in Julia does not return full square matrices for `U` and `V`. Consequently, `V[:, end]` may not correspond to the right singular vector associated with the smallest singular value. This undermines the logic of the `aaa` algorithm, as it relies on that vector to compute barycentric weights.
```julia
julia> using LinearAlgebra

julia> A = rand(2,4)
2×4 Matrix{Float64}:
 0.871675  0.692711  0.377506  0.991387
 0.60177   0.585258  0.599331  0.0707412

julia> V = svd(A).V
4×2 adjoint(::Matrix{Float64}) with eltype Float64:
 -0.600056   0.114101
 -0.508215   0.250297
 -0.3591     0.554533
 -0.50269   -0.785383

julia> norm(A*V[:,end])≈ 0
false

julia> norm(A*V[:,end])
0.5743521599078463
```

2. Once the number of nodes exceeds the number of test points (i.e., `n > m - n`), the residuals become trivially zero, which indicates overfitting and causes the rational approximation to lose generalization.

Therefore, I suggest adding an explicit termination condition in the `aaa` function: **terminate the iteration once the Loewner would be wide matrix in next iteration**.
```julia
if n>=((m+1)>>1) break end
```
This change ensures both numerical stability and model robustness.

Below is a comparison of the original `aaa` implementation and the improved version incorporating this condition:
```julia
using  Plots, QuadGK, Random, RationalFunctionApproximation

# construct combanition of gauss waves
function continous_spectral_density(μ::Vector{Float64}, σ::Vector{Float64}, amplitude::Vector{Float64})
    @assert length(μ) == length(σ) == length(amplitude)
    n = length(μ)
    function y(x::Float64)
        res = 0
        for i = 1:n
            res += amplitude[i] * exp(-(x - μ[i])^2 / (2 * σ[i]^2))
        end
        return res
    end
    return y
end

# generate values of G(iw_n)
function generate_G_values_cont(β::Float64, N::Int64, A; int_low::Float64=-20.0, int_up::Float64=20.0, noise::Float64=0.0)
    grid = (collect(0:N-1) .+ 0.5) * 2π / β
    n = length(grid)
    res = zeros(ComplexF64, n)
    for i = 1:n
        res[i] = quadgk(x -> A(x) / (im * grid[i] - x), int_low, int_up)[1]
    end
    for i = 1:n
        res[i] += noise * randn() * res[i] * exp(2π * im * rand())
    end
    return res
end

function correct_aaa(;
    seed=6,
    μ=[0.5, -2.5],
    σ=[0.2, 0.8],
    amplitude=[1.0, 0.3],
    β=10.0,
    N=20,
    output_bound=8.0,
    output_number=801,
    noise=1e-5)
    Random.seed!(seed)
    iwn = collect((0:N-1) .+ 0.5) * 2π / β * im
    mesh = collect(range(-output_bound, output_bound, length=output_number))
    A = continous_spectral_density(μ, σ, amplitude)
    GFV = generate_G_values_cont(β, N, A; noise=noise)
    reG = aaa(GFV,iwn)
    reA = - imag(reG.(mesh))./π

    return mesh, reA, A.(mesh)
end

mesh, reA, originA = correct_aaa()

plot(mesh, reA, label="reconstruct spectral density")
plot!(mesh, originA, label="origin spectral density")
```
The original `AAA` yields
![original_aaa_reA](https://github.com/user-attachments/assets/9455fc6b-2985-49ab-b43c-c8cabd49ca72)
![original_aaa](https://github.com/user-attachments/assets/d8101a40-84bb-4a97-ac7b-7fdcbe9908cf)


The corrected `AAA` yields
![correct_aaa](https://github.com/user-attachments/assets/2c25758e-4907-44a5-974f-4dce5be3bab2)