### PR TITLE
Increase numerical stability of `poles` for a barycentric model

### DIFF
--- a/src/barycentric.jl
+++ b/src/barycentric.jl
@@ -212,8 +212,8 @@ function poles(r::Barycentric{T,S}) where {T,S}
         pol = filter( isfinite, eigvals(E, B) )
     catch
         # generalized eigen not available in extended precision, so:
-        λ = filter( z->abs(z)>1e-13, eigvals(E\B) )
-        pol = 1 ./ λ
+        (; α, β) = schur(complex(E), complex(B))
+        pol = filter( isfinite, α ./ β )
     end
     return pol
 end


### PR DESCRIPTION
Since generalized `eigvals(E, B)` is missing for high-precision floats, we can implement it ourselves using a complex Schur decomposition. This greatly improves the accuracy of the `poles` calculation, as per the test case in https://github.com/complexvariables/RationalFunctionApproximation.jl/issues/21#issuecomment-3666064855. Fixes #21.

This PR _does_ reorder the poles. Does RFA make implicit guarantees about this ordering?

Apart from this PR, Issue #21 identifies some strange behaviors in `approximate` with fixed poles. But that seems less pressing.