### PR TITLE
Fix discrete construction for real functions on complex domain

### DIFF
--- a/src/thiele.jl
+++ b/src/thiele.jl
@@ -563,12 +563,15 @@ function approximate(::Type{Thiele},
     z_test = copy(collect(z))
     deleteat!(y_test, idx_min)
     deleteat!(z_test, idx_min)
-    r_test = similar(y_test)
+    r_test = similar(y_test, promote_type(S, T))
 
     history = [IterationRecord(r, NaN, missing)]
     n = 1    # iteration counter
     while length(z) > 0
         evaluate!(r_test, r, z_test)
+        @inbounds for i in eachindex(r_test)   # array evaluation skips the underflow check
+            isnan(r_test[i]) && (r_test[i] = r(z_test[i]))
+        end
         r_test .-= y_test
         err_max, idx_max = findmax(abs(e) for e in r_test)
         history[n].error = err_max

--- a/test/discrete.jl
+++ b/test/discrete.jl
@@ -45,6 +45,7 @@
         f = x -> cis(x);  @test pass(f, approx(f), pts, atol=6e-13)
         f = z -> tan(π*z);  @test pass(f, approx(f), pts, rtol=2e-13)
         f = z -> tanh(100z); @test pass(f, approx(f), pts, rtol=2e-13)
+        f = z -> abs(z + 1.05); @test pass(f, approx(f), pts, rtol=1e-10)
     end
 
     @testset "Discrete interval, low accuracy" begin


### PR DESCRIPTION
In Thiele discrete construction, values of r may be complex if nodes are complex, even if given values are real.