### PR TITLE
docs: Fix typo in installation instructions

### DIFF
--- a/docs/src/install.md
+++ b/docs/src/install.md
@@ -3,7 +3,7 @@
 You can download and install this package using the general registry:
 
 ```julia
-import Pkg; Pkg.add("RationalFunctionInterpolation")
+import Pkg; Pkg.add("RationalFunctionApproximation")
 ```
 
 If you are going to use domains other than real intervals and the unit circle, you should also install `ComplexRegions`:


### PR DESCRIPTION
## Description
Fixes a typo in the installation command within the documentation (`Pkg.add("RationalFunctionInterpolation")` -> `Pkg.add("RationalFunctionApproximation")`).

## Changes
- Corrected the typo in `docs/src/install.md`

## Checklist
- [x] Documentation has been updated accordingly.